### PR TITLE
refactor: use whiskers

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers pyradio.tera

--- a/pyradio.tera
+++ b/pyradio.tera
@@ -1,39 +1,46 @@
+---
+whiskers:
+  version: "2.2.0"
+  matrix:
+    - flavor
+  filename: "src/catppuccin-{{ flavor.identifier }}.pyradio-theme"
+---
 # Main foreground and background
-Stations            #cad3f5 #24273a
+Stations            #{{ text.hex }} #{{ base.hex }}
 
 # Playing station text color
 # (background color will come from Stations)
-Active Station      #a6da95
+Active Station      #{{ green.hex }}
 
 # Status bar foreground and background
-Status Bar          #24273a #a6da95
+Status Bar          #{{ base.hex }} #{{ green.hex }}
 
 # Normal cursor foreground and background
-Normal Cursor       #cad3f5 #363a4f
+Normal Cursor       #{{ text.hex }} #{{ surface0.hex }}
 
 # Cursor foreground and background
 # when cursor on playing station
-Active Cursor       #24273a #b7bdf8
+Active Cursor       #{{ base.hex }} #{{ lavender.hex }}
 
 # Cursor foreground and background
 # This is the Line Editor cursor
-Edit Cursor         #24273a #f4dbd6
+Edit Cursor         #{{ base.hex }} #{{ rosewater.hex }}
 
 # Text color for extra function indication
 # and jump numbers within the status bar
 # (background color will come from Stations)
-Extra Func          #c6a0f6
+Extra Func          #{{ mauve.hex }}
 
 # Text color for URL
 # (background color will come from Stations)
-PyRadio URL         #c6a0f6
+PyRadio URL         #{{ mauve.hex }}
 
 # Message window border foreground and background.
 # The background color can be left unset.
 # Please refer to the following link for more info
 # https://github.com/coderholic/pyradio#secondary-windows-background
 #
-Messages Border     #c6a0f6
+Messages Border     #{{ mauve.hex }}
 
 # Theme Transparency
 # Values are:

--- a/src/catppuccin-frappe.pyradio-theme
+++ b/src/catppuccin-frappe.pyradio-theme
@@ -1,39 +1,39 @@
 # Main foreground and background
-Stations            #C6D0F5 #303446
+Stations            #c6d0f5 #303446
 
 # Playing station text color
 # (background color will come from Stations)
-Active Station      #A6D189
+Active Station      #a6d189
 
 # Status bar foreground and background
-Status Bar          #303446 #A6D189
+Status Bar          #303446 #a6d189
 
 # Normal cursor foreground and background
-Normal Cursor       #C6D0F5 #414559
+Normal Cursor       #c6d0f5 #414559
 
 # Cursor foreground and background
 # when cursor on playing station
-Active Cursor       #303446 #BABBF1
+Active Cursor       #303446 #babbf1
 
 # Cursor foreground and background
 # This is the Line Editor cursor
-Edit Cursor         #303446 #F2D5CF
+Edit Cursor         #303446 #f2d5cf
 
 # Text color for extra function indication
 # and jump numbers within the status bar
 # (background color will come from Stations)
-Extra Func          #CA9EE6
+Extra Func          #ca9ee6
 
 # Text color for URL
 # (background color will come from Stations)
-PyRadio URL         #CA9EE6
+PyRadio URL         #ca9ee6
 
 # Message window border foreground and background.
 # The background color can be left unset.
 # Please refer to the following link for more info
 # https://github.com/coderholic/pyradio#secondary-windows-background
 #
-Messages Border     #CA9EE6  
+Messages Border     #ca9ee6
 
 # Theme Transparency
 # Values are:

--- a/src/catppuccin-latte.pyradio-theme
+++ b/src/catppuccin-latte.pyradio-theme
@@ -1,39 +1,39 @@
 # Main foreground and background
-Stations            #4C4F69 #EFF1F5
+Stations            #4c4f69 #eff1f5
 
 # Playing station text color
 # (background color will come from Stations)
-Active Station      #40A02B
+Active Station      #40a02b
 
 # Status bar foreground and background
-Status Bar          #EFF1F5 #40A02B
+Status Bar          #eff1f5 #40a02b
 
 # Normal cursor foreground and background
-Normal Cursor       #4C4F69 #CCD0DA
+Normal Cursor       #4c4f69 #ccd0da
 
 # Cursor foreground and background
 # when cursor on playing station
-Active Cursor       #EFF1F5 #7287FD
+Active Cursor       #eff1f5 #7287fd
 
 # Cursor foreground and background
 # This is the Line Editor cursor
-Edit Cursor         #EFF1F5 #DC8A78
+Edit Cursor         #eff1f5 #dc8a78
 
 # Text color for extra function indication
 # and jump numbers within the status bar
 # (background color will come from Stations)
-Extra Func          #8839EF
+Extra Func          #8839ef
 
 # Text color for URL
 # (background color will come from Stations)
-PyRadio URL         #8839EF
+PyRadio URL         #8839ef
 
 # Message window border foreground and background.
 # The background color can be left unset.
 # Please refer to the following link for more info
 # https://github.com/coderholic/pyradio#secondary-windows-background
 #
-Messages Border     #8839EF 
+Messages Border     #8839ef
 
 # Theme Transparency
 # Values are:

--- a/src/catppuccin-mocha.pyradio-theme
+++ b/src/catppuccin-mocha.pyradio-theme
@@ -1,39 +1,39 @@
 # Main foreground and background
-Stations            #CDD6F4 #1E1E2E
+Stations            #cdd6f4 #1e1e2e
 
 # Playing station text color
 # (background color will come from Stations)
-Active Station      #A6E3A1
+Active Station      #a6e3a1
 
 # Status bar foreground and background
-Status Bar          #1E1E2E #A6E3A1
+Status Bar          #1e1e2e #a6e3a1
 
 # Normal cursor foreground and background
-Normal Cursor       #CDD6F4 #313244
+Normal Cursor       #cdd6f4 #313244
 
 # Cursor foreground and background
 # when cursor on playing station
-Active Cursor       #1E1E2E #B4BEFE
+Active Cursor       #1e1e2e #b4befe
 
 # Cursor foreground and background
 # This is the Line Editor cursor
-Edit Cursor         #1E1E2E #F5E0DC
+Edit Cursor         #1e1e2e #f5e0dc
 
 # Text color for extra function indication
 # and jump numbers within the status bar
 # (background color will come from Stations)
-Extra Func          #CBA6F7
+Extra Func          #cba6f7
 
 # Text color for URL
 # (background color will come from Stations)
-PyRadio URL         #CBA6F7
+PyRadio URL         #cba6f7
 
 # Message window border foreground and background.
 # The background color can be left unset.
 # Please refer to the following link for more info
 # https://github.com/coderholic/pyradio#secondary-windows-background
 #
-Messages Border     #CBA6F7  
+Messages Border     #cba6f7
 
 # Theme Transparency
 # Values are:


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's internal templating tool, to build the themes. Instead of editing the `.pyradio-theme` files directly, edit the `pyradio.tera` file and then run `just build` to build the output themes. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) installed.